### PR TITLE
Simplified the base pattern, added build.sh and updated readme.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,47 @@
-# GKE Batch and AI/ML recipes
+# Reference Architecture for a Batch Processing Platform on GKE
 
-## Summary
+## Purpose
 
-This repository contains samples and in-progress content intended to be merged into the officially supported GKE samples.
+This tutorial provides patterns to setup batch processing platforms on [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview) (GKE). The Base folder contains the basic infrastructure required for all examples in this repository.
 
-## Usage
-Each Batch and AI/ML sample will be based on an infrastructure pattern layed out in the `base` directory. Simply copy the content in `base` to a working directory inside `batch` or `aiml` and begin adding customization for the related sample content.
+## Prerequistes 
 
-In your working directory, replace the value of `YOUR_GCS_BUCKET_NAME` in `backend.tf` to a GCS bucket that you have created to host the state information from Terraform.
+1. This tutorial has been tested on [Cloud Shell](https://shell.cloud.google.com) which comes preinstalled with [Google Cloud SDK](https://cloud.google.com/sdk) and [Terraform](https://www.terraform.io/) which are required to complete this tutorial.
 
-Then do a terraform init, plan and apply flow to complete the infrastructure build process while providing the Project ID when Terraform asks for it.
+2. It is recommended to start the tutorial in a fresh project since the easiest way to clean up once complete is to delete the project. See [here](https://cloud.google.com/resource-manager/docs/creating-managing-projects) for more details.
 
+## Deploy resources using Terraform.
 
-## Contribution
+1. Create a working directory, clone this repo and switch to the appropriate branch.
 
-Please feel free to open pull requests against `main`, all contributions welcome.
+    ```bash
+    mkdir ~/gke-tutorial && cd ~/gke-tutorial && export WORKDIR=$(pwd)
+    gcloud source repos clone terraform-sandbox --project=zaidiali-src
+    cd gke-batch-aiml/base
+    ```
+
+1. Export the `PROJECT_ID` environment variable; replace the value of `YOUR_PROJECT_ID` with that of a fresh project you created for this tutorial. The rest of this step enables the required APIs, creates an IAM policy binding for the Cloud Build service account, creates an Artifact Registry to host the Cloud Build container images and submit a Cloud Build job to create the required Google Cloud resources. For more details see `build.sh` in the `base` directory.
+   
+   ```bash
+   export PROJECT_ID=YOUR_PROJECT_ID
+   ./build.sh
+   ```
+
+## Clean up
+
+1. The easiest way to prevent continued billing for the resources that you created for this tutorial is to delete the project you created for the tutorial. Run the following commands from Cloud Shell:
+
+   ```bash
+    gcloud config unset project
+    echo y | gcloud projects delete $PROJECT_ID
+    rm -rf $WORKDIR
+    ```
+2. If the project needs to be left intact, the second option is to destroy the infrastructure created for this tutorial using Cloud Build.
+
+   ```bash
+    gcloud builds submit \
+     --region=us-west1 \
+     --config cloudbuild-destroy.yaml \
+     --async
+    rm -rf $WORKDIR
+    ```

--- a/aiml/traingpumodel.md
+++ b/aiml/traingpumodel.md
@@ -1,1 +1,0 @@
-# Tutorial: Training an ML model with GPU on GKE

--- a/aiml/traintpumodel.md
+++ b/aiml/traintpumodel.md
@@ -1,1 +1,0 @@
-# Tutorial: Training an ML model with TPU on GKE

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+
+RUN apk --update add --no-cache \
+coreutils \
+git \
+curl \
+gettext \
+jq \
+openssl \
+python3 \
+unzip \
+wget
+
+ENV TERRAFORM_VERSION=1.3.7
+
+# Install terraform
+RUN echo "INSTALL TERRAFORM v${TERRAFORM_VERSION}" \
+&& wget -q -O terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+&& unzip terraform.zip \
+&& chmod +x terraform \
+&& mv terraform /usr/local/bin \
+&& rm -rf terraform.zip
+
+# Install additional tools
+RUN gcloud components install \
+kubectl \
+&& rm -rf $(find google-cloud-sdk/ -regex ".*/__pycache__") \
+&& rm -rf google-cloud-sdk/.install/.backup

--- a/base/backend.tf
+++ b/base/backend.tf
@@ -1,5 +1,0 @@
-terraform {
-  backend "gcs" {
-    bucket = "YOUR_GCS_BUCKET_NAME"
-  }
-}

--- a/base/build.sh
+++ b/base/build.sh
@@ -1,0 +1,33 @@
+[[ ! "${PROJECT_ID}" ]] && echo -e "Please export PROJECT_ID variable (\e[95mexport PROJECT_ID=<YOUR POROJECT ID>\e[0m)\nExiting." && exit 0
+echo -e "\e[95mPROJECT_ID is set to ${PROJECT_ID}\e[0m"
+gcloud config set core/project ${PROJECT_ID}
+export PROJECT_NUM=$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')
+export TF_CLOUDBUILD_SA="${PROJECT_NUM}@cloudbuild.gserviceaccount.com"
+echo -e "$TF_CLOUDBUILD_SA"
+echo -e "\e[95mEnabling required APIs in ${PROJECT_ID}\e[0m"
+gcloud --project="${PROJECT_ID}" services enable \
+ cloudapis.googleapis.com \
+ compute.googleapis.com \
+ servicenetworking.googleapis.com \
+ iam.googleapis.com \
+ cloudbuild.googleapis.com \
+ artifactregistry.googleapis.com \
+ container.googleapis.com \
+ cloudtrace.googleapis.com \
+ monitoring.googleapis.com \
+ logging.googleapis.com \
+ storage.googleapis.com \
+ mesh.googleapis.com \
+ cloudresourcemanager.googleapis.com
+
+echo -e "\e[95mAssigning Cloudbuild Service Account roles/owner in ${PROJECT_ID}\e[0m"
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" --member serviceAccount:"${TF_CLOUDBUILD_SA}" --role roles/owner
+
+echo -e "\e[95mStarting Cloudbuild to create infrastructure...\e[0m"
+
+[[ $(gcloud artifacts repositories list | grep "platform-installer") ]] || \
+gcloud artifacts repositories create platform-installer --repository-format=docker --location=us-west1 --description="Repo for platform installer container images built by Cloud Build."
+
+gcloud builds submit --config cloudbuild-create.yaml --async
+
+echo -e "\e[95mYou can view the Cloudbuild status through https://console.cloud.google.com/cloud-build\e[0m"

--- a/base/cloudbuild-create.yaml
+++ b/base/cloudbuild-create.yaml
@@ -1,0 +1,48 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 3600s
+steps:
+  - name: "gcr.io/kaniko-project/executor:v1.9.1-slim"
+    id: "build-installer-image"
+    args:
+      - --destination=us-west1-docker.pkg.dev/${PROJECT_ID}/platform-installer/installer
+      - --cache=true
+      - --cache-ttl=12h
+  - name: "gcr.io/cloud-builders/gcloud"
+    id: "gcs"
+    waitFor: ["-"]
+    entrypoint: "bash"
+    args:
+      - "-xe"
+      - "-c"
+      - |
+        [[ $(gsutil ls | grep "gs://${PROJECT_ID}-tfstate/") ]] || \
+        gsutil mb -p ${PROJECT_ID} gs://${PROJECT_ID}-tfstate && \
+        [[ $(gsutil versioning get gs://${PROJECT_ID}-tfstate | grep Enabled) ]] || \
+        gsutil versioning set on gs://${PROJECT_ID}-tfstate
+  - name: "us-west1-docker.pkg.dev/${PROJECT_ID}/platform-installer/installer"
+    id: "gke"
+    dir: "gke"
+    entrypoint: "ash"
+    args:
+      - "-xe"
+      - "-c"
+      - |
+        echo "project_id = \"${PROJECT_ID}\"" > terraform.tfvars
+        terraform init -backend-config="bucket=${PROJECT_ID}-tfstate"
+        terraform plan -out terraform.tfplan
+        terraform apply -input=false -lock=false terraform.tfplan
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/base/cloudbuild-destroy.yaml
+++ b/base/cloudbuild-destroy.yaml
@@ -1,0 +1,35 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 3600s
+steps:
+  - name: "gcr.io/kaniko-project/executor:v1.6.0"
+    id: "build-installer-image"
+    args:
+      - --destination=us-west1-docker.pkg.dev/${PROJECT_ID}/platform-installer/installer
+      - --cache=true
+      - --cache-ttl=12h
+  - name: "us-west1-docker.pkg.dev/${PROJECT_ID}/platform-installer/installer"
+    id: "gke"
+    dir: "gke"
+    entrypoint: "ash"
+    args:
+      - "-xe"
+      - "-c"
+      - |
+        echo "project_id = \"${PROJECT_ID}\"" > terraform.tfvars
+        terraform init -backend-config="bucket=${PROJECT_ID}-tfstate"
+        terraform destroy -auto-approve
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/base/gke/Dockerfile
+++ b/base/gke/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+
+RUN apk --update add --no-cache \
+coreutils \
+git \
+curl \
+gettext \
+jq \
+openssl \
+python3 \
+unzip \
+wget
+
+ENV TERRAFORM_VERSION=1.1.7
+
+# Install terraform
+RUN echo "INSTALL TERRAFORM v${TERRAFORM_VERSION}" \
+&& wget -q -O terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+&& unzip terraform.zip \
+&& chmod +x terraform \
+&& mv terraform /usr/local/bin \
+&& rm -rf terraform.zip
+
+# Install additional tools
+RUN gcloud components install \
+kubectl \
+&& rm -rf $(find google-cloud-sdk/ -regex ".*/__pycache__") \
+&& rm -rf google-cloud-sdk/.install/.backup

--- a/base/gke/backend.tf
+++ b/base/gke/backend.tf
@@ -1,0 +1,19 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  backend "gcs"{
+    prefix      = "gke"
+  }
+}

--- a/base/gke/cloudbuild.yaml
+++ b/base/gke/cloudbuild.yaml
@@ -1,0 +1,35 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 3600s
+steps:
+  - name: "gcr.io/kaniko-project/executor:v1.6.0"
+    id: "build-installer-image"
+    args:
+      - --destination=us-west1-docker.pkg.dev/${PROJECT_ID}/platform-installer/installer
+      - --cache=true
+      - --cache-ttl=12h
+  - name: "us-west1-docker.pkg.dev/${PROJECT_ID}/platform-installer/installer"
+    id: "gke"
+    entrypoint: "ash"
+    args:
+      - "-xe"
+      - "-c"
+      - |
+        echo "project_id = \"${PROJECT_ID}\"" > terraform.tfvars
+        terraform init -backend-config="bucket=${PROJECT_ID}-tfstate"
+        terraform plan -out terraform.tfplan
+        terraform apply -input=false -lock=false terraform.tfplan
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/base/gke/main.tf
+++ b/base/gke/main.tf
@@ -1,19 +1,25 @@
-module "enable_google_apis" {
-  source     = "terraform-google-modules/project-factory/google//modules/project_services"
-  version    = "14.1.0"
-  project_id = var.project_id
-  activate_apis = [
-    "cloudapis.googleapis.com",
-    "compute.googleapis.com",
-    "container.googleapis.com",
-  ]
-  disable_services_on_destroy = false
-}
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# google_client_config and kubernetes provider must be explicitly specified like the following for every cluster.
+
+## GKE cluster
 
 data "google_client_config" "default" {}
 
 provider "kubernetes" {
-  host                   = "https://${module.gke.endpoint}"
+  host                   = "https://${resource.google_container_cluster.gke_batch.endpoint}"
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
@@ -47,7 +53,7 @@ resource "google_container_node_pool" "ondemand_np" {
   }
   autoscaling {
       min_node_count = 1
-      max_node_count = 9
+      max_node_count = 3
       location_policy = "ANY"
   }
   timeouts {
@@ -108,7 +114,7 @@ resource "google_container_node_pool" "spot_gpu_np" {
     ]
   }
   autoscaling {
-      min_node_count = 1
+      min_node_count = 0
       max_node_count = 3
       location_policy = "ANY"
   }
@@ -117,4 +123,3 @@ resource "google_container_node_pool" "spot_gpu_np" {
     update = "20m"
   }
 }
-

--- a/base/gke/outputs.tf
+++ b/base/gke/outputs.tf
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_location" {
+  value = google_container_cluster.gke_batch.location
+}
+
+output "cluster_name" {
+  value = google_container_cluster.gke_batch.name
+}

--- a/base/gke/providers.tf
+++ b/base/gke/providers.tf
@@ -1,0 +1,40 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "4.54.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "4.54.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "2.18.1"
+    }
+  }
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/base/gke/variables.tf
+++ b/base/gke/variables.tf
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "The GCP project where the GKE cluster will be created"
+}
+
+variable "region" {
+  type        = string
+  description = "The GCP region where the GKE cluster will be created"
+  default = "us-central1"
+}
+

--- a/base/vars.tf
+++ b/base/vars.tf
@@ -1,5 +1,0 @@
-variable "region" {
-    default = "us-central1"
-}
-
-variable "project_id" {}

--- a/batch/cronjob.md
+++ b/batch/cronjob.md
@@ -1,1 +1,0 @@
-# Tutorial: CronJob on GKE

--- a/batch/indexedjob.md
+++ b/batch/indexedjob.md
@@ -1,1 +1,0 @@
-# Tutorial: Indexed Job on GKE

--- a/examples/aiml/tpu_training.md
+++ b/examples/aiml/tpu_training.md
@@ -1,0 +1,1 @@
+Placeholder for content.

--- a/examples/batch/indexedjob.md
+++ b/examples/batch/indexedjob.md
@@ -1,0 +1,1 @@
+Placeholder for content.


### PR DESCRIPTION
This PR simplifies the setup process. The user clones the repository, exports an environment variable for their GCP project and kicks off the build script that prepares and starts the Cloud Build job to build base infrastructure.